### PR TITLE
Fix order of instructions

### DIFF
--- a/offsite-activity-signup/README.md
+++ b/offsite-activity-signup/README.md
@@ -27,11 +27,11 @@ assign the activities to best match their preferences, activity capacities, and 
 1. Click on custom menu item **Activities** > **Create Form**.
 1. A dialog box will appear and tell you that the script requires authorization. Read the authorization notice
    and continue.
-1. Click on custom menu item **Activities > Generate test data** to generate sample responses.
+1. Click on custom menu item **Activities** > **Generate test data** to generate sample responses.
 1. Click **Form** > **Go to live form**.
 1. Fill out the form and submit your own response.
 1. Return to the sheet.
-1. Click on custom menu item **Activities > Assign activities**.
+1. Click on custom menu item **Activities** > **Assign activities**.
 1. Two new sheets will appear with the activity assignments. View them.
 
 ## Next steps

--- a/offsite-activity-signup/README.md
+++ b/offsite-activity-signup/README.md
@@ -27,10 +27,10 @@ assign the activities to best match their preferences, activity capacities, and 
 1. Click on custom menu item **Activities** > **Create Form**.
 1. A dialog box will appear and tell you that the script requires authorization. Read the authorization notice
    and continue.
-1. You will see a new **Form** menu. Click it and select **Go to live form**.
-1. Fill out the form and submit your response.
+1. Click on custom menu item **Activities > Generate test data** to generate sample responses.
+1. Click **Form** > **Go to live form**.
+1. Fill out the form and submit your own response.
 1. Return to the sheet.
-1. Click on custom menu item **Activities > Generate test data** to generate additional responses.
 1. Click on custom menu item **Activities > Assign activities**.
 1. Two new sheets will appear with the activity assignments. View them.
 


### PR DESCRIPTION
Generate test data currently requires form responses to be empty. Tweak instructions to reflect that, switch test vs. personal response.