### PR TITLE
Email index correction

### DIFF
--- a/timesheets/src/Code.js
+++ b/timesheets/src/Code.js
@@ -14,7 +14,7 @@
 
 // Global variables representing the index of certain columns.
 var COLUMN_NUMBER = {
-  EMAIL: 3,
+  EMAIL: 2,
   HOURS_START: 4,
   HOURS_END: 8,
   HOURLY_PAY: 9,


### PR DESCRIPTION
Column indexing for getRange starts at 1. So EMAIL should be 2 as it is in the second column.